### PR TITLE
Fix minor typo on KAN Class width description

### DIFF
--- a/kan/KAN.py
+++ b/kan/KAN.py
@@ -25,7 +25,7 @@ class KAN(nn.Module):
         depth: int
             depth of KAN
         width: list
-            number of neurons in each layer. e.g., [2,5,5,3] means 2D inputs, 5D outputs, with 2 layers of 5 hidden neurons.
+            number of neurons in each layer. e.g., [2,5,5,3] means 2D inputs, 3D outputs, with 2 layers of 5 hidden neurons.
         grid: int
             the number of grid intervals
         k: int


### PR DESCRIPTION
Love your paper! While reading the docs, I found a minor typo in the core class parameter description. As far as I know, the end of the list is the dimension of the output layer. And in this commit I change the output number for a width list of `[2,5,5,3]` from 5 to 3. Let me know if my understanding is wrong.

Will checks all the docs as I try the MLP use cases. Thank you!