### PR TITLE
[CVE-2022-40897] - Added setuptools security fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib==3.6.2
 numpy==1.24.4
 scikit_learn==1.1.3
-setuptools==65.5.0
+setuptools==65.5.1
 sympy==1.11.1
 torch==2.2.2
 tqdm==4.66.2


### PR DESCRIPTION
**Description**
setuptools==65.5.0 version is vulnerable to Regular Expression Denial of Service (ReDoS) via crafted HTML package or custom PackageIndex page.

**Recommendation:** Upgrade setuptools to version 65.5.1 or higher.

**Changes Made:** setuptools==65.5.1

**Reference:**
https://nvd.nist.gov/vuln/detail/CVE-2022-40897