### PR TITLE
Fix error on cpu device in KANLayer.py

### DIFF
--- a/kan/KANLayer.py
+++ b/kan/KANLayer.py
@@ -123,7 +123,7 @@ class KANLayer(nn.Module):
         if isinstance(scale_base, float):
             self.scale_base = torch.nn.Parameter(torch.ones(size, device=device) * scale_base).requires_grad_(sb_trainable)  # make scale trainable
         else:
-            self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base).cuda()).requires_grad_(sb_trainable)
+            self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base).to(device)).requires_grad_(sb_trainable)
         self.scale_sp = torch.nn.Parameter(torch.ones(size, device=device) * scale_sp).requires_grad_(sp_trainable)  # make scale trainable
         self.base_fun = base_fun
 


### PR DESCRIPTION
Upon attempting to run tutorials on the CPU device, I encountered the following error: `RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!`. 
To address this issue, I've made adjustments in the code from using `cuda()` to `to(device)`. This modification ensures compatibility with both CPU and CUDA devices.