### PR TITLE
improve the compatibility with non-CUDA environments

### DIFF
--- a/kan/KANLayer.py
+++ b/kan/KANLayer.py
@@ -123,7 +123,10 @@ class KANLayer(nn.Module):
         if isinstance(scale_base, float):
             self.scale_base = torch.nn.Parameter(torch.ones(size, device=device) * scale_base).requires_grad_(sb_trainable)  # make scale trainable
         else:
-            self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base).to(device)).requires_grad_(sb_trainable)
+            if torch.cuda.is_available():
+                self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base).cuda()).requires_grad_(sb_trainable)
+            else:
+                self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base)).requires_grad_(sb_trainable)
         self.scale_sp = torch.nn.Parameter(torch.ones(size, device=device) * scale_sp).requires_grad_(sp_trainable)  # make scale trainable
         self.base_fun = base_fun
 


### PR DESCRIPTION
Many thanks to the author for proposing this amazing KAN. I modified the KANLayer.py file for better compatibility in non-CUDA environments. BTW, it is my first pull request. I would appreciate it if you could accept this request. @KindXiaoming 

Before:
line 126 in KANLayer.py
`self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base)).requires_grad_(sb_trainable)
`
After:
`            if torch.cuda.is_available():
                self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base).cuda()).requires_grad_(sb_trainable)
            else:
                self.scale_base = torch.nn.Parameter(torch.FloatTensor(scale_base)).requires_grad_(sb_trainable)`