### PR TITLE
adding output_normalizer

### DIFF
--- a/kan/KAN.py
+++ b/kan/KAN.py
@@ -1158,7 +1158,7 @@ class KAN(nn.Module):
                         if verbose >= 1:
                             print(f'fixing ({l},{i},{j}) with {name}, r2={r2}')
 
-    def symbolic_formula(self, floating_digit=2, var=None, normalizer=None, simplify=False):
+    def symbolic_formula(self, floating_digit=2, var=None, normalizer=None, simplify=False, output_normalizer = None ):
         '''
         obtain the symbolic formula
         
@@ -1172,6 +1172,8 @@ class KAN(nn.Module):
                 the normalization applied to inputs
             simplify : bool
                 If True, simplify the equation at each step (usually quite slow), so set up False by default.
+            output_normalizer: [mean array (floats), varaince array (floats)]
+                the normalization applied to outputs
             
         Returns:
         --------
@@ -1235,6 +1237,19 @@ class KAN(nn.Module):
 
             x = y
             symbolic_acts.append(x)
+
+        if output_normalizer != None:
+            output_layer = symbolic_acts[-1]
+            means = output_normalizer[0]
+            stds = output_normalizer[1]
+
+            assert len(output_layer) == len(means), 'output_normalizer does not match the output layer'
+            assert len(output_layer) == len(stds), 'output_normalizer does not match the output layer'
+            
+            output_layer = [(output_layer[i] * stds[i] + means[i]) for i in range(len(output_layer))]
+            symbolic_acts[-1] = output_layer
+
+
 
         self.symbolic_acts = [[ex_round(symbolic_acts[l][i]) for i in range(len(symbolic_acts[l]))] for l in range(len(symbolic_acts))]
 


### PR DESCRIPTION
adds the possibility of normalizing the outputs of a symbolic fn as well.


```python
import torch
import numpy
import pandas

n = 10000
w = numpy.random.normal(0, 1, n)
x = 10 * w + numpy.random.normal(0, 1, n)
z = 15 * w + numpy.random.normal(0, 1, n)
y = 4 * x + 4 * z + numpy.random.normal(0, 1, n)

data = pandas.DataFrame({"x": x, "y": y, "z": z, "w": w})

means = data.mean()
stds = data.std()

node = "y"
parents = ["x", "z"]

scaled_data = (data - means) / stds
X, y = scaled_data[parents], scaled_data[[node]]
X_train, X_test, y_train, y_test = X[:8000], X[8000:], y[:8000], y[8000:]

dataset = {}
dataset["train_input"] = torch.from_numpy(X_train.values).float()
dataset["test_input"] = torch.from_numpy(X_test.values).float()
dataset["train_label"] = torch.from_numpy(y_train.values).float()
dataset["test_label"] = torch.from_numpy(y_test.values).float()

model = KAN(width=[2, 1], k=3, grid=5)
model.train(dataset, steps=20)
model.auto_symbolic(lib=["x"])

node = "y"
parents = ["x", "z"]


means_list = [means[p] for p in parents]
stds_list = [stds[p] for p in parents]

output_mean = means[node]
output_std = stds[node]

model.symbolic_formula(
    normalizer=[means_list, stds_list], output_normalizer=[[output_mean], [output_std]]
)
```

with output normalizer:  `([3.98*x_1 + 4.02*x_2 - 0.02], [x_1, x_2])`
without: `([0.04*x_1 + 0.04*x_2 + 0.01], [x_1, x_2])`