### PR TITLE
Fix dtype error when input dtype is Double

### DIFF
--- a/kan/spline.py
+++ b/kan/spline.py
@@ -97,6 +97,8 @@ def coef2curve(x_eval, grid, coef, k, device="cpu"):
     '''
     # x_eval: (size, batch), grid: (size, grid), coef: (size, coef)
     # coef: (size, coef), B_batch: (size, coef, batch), summer over coef
+    if coef.dtype != x_eval.dtype:
+        coef = coef.to(x_eval.dtype)
     y_eval = torch.einsum('ij,ijk->ik', coef, B_batch(x_eval, grid, k, device=device))
     return y_eval
 


### PR DESCRIPTION
In issues #105, #113 and #127, it was discovered that using input data type Double (np.float64) resulted in a `RuntimeError: expected scalar type Double but found Float`. This PR proposes a solution by ensuring that the `coef` variable matches the data type of `x_eval`.