### PR TITLE
Fix dtype error in `curve2coef`

### DIFF
--- a/kan/spline.py
+++ b/kan/spline.py
@@ -133,6 +133,6 @@ def curve2coef(x_eval, y_eval, grid, k, device="cpu"):
     torch.Size([5, 13])
     '''
     # x_eval: (size, batch); y_eval: (size, batch); grid: (size, grid); k: scalar
-    mat = B_batch(x_eval, grid, k, device=device).permute(0, 2, 1)
+    mat = B_batch(x_eval, grid, k, device=device).permute(0, 2, 1).to(y_eval.dtype)
     coef = torch.linalg.lstsq(mat.to('cpu'), y_eval.unsqueeze(dim=2).to('cpu')).solution[:, :, 0]  # sometimes 'cuda' version may diverge
     return coef.to(device)


### PR DESCRIPTION
To address issue #146, where input data type float64 led to a `RuntimeError: expected scalar type Double but found Float`, this PR proposes a solution by ensuring that the `mat` variable aligns with the data type of `y_eval`.