### PR TITLE
Update grid for CUDA

### DIFF
--- a/kan/spline.py
+++ b/kan/spline.py
@@ -135,6 +135,6 @@ def curve2coef(x_eval, y_eval, grid, k, device="cpu"):
     # x_eval: (size, batch); y_eval: (size, batch); grid: (size, grid); k: scalar
     mat = B_batch(x_eval, grid, k, device=device).permute(0, 2, 1)
     # coef = torch.linalg.lstsq(mat, y_eval.unsqueeze(dim=2)).solution[:, :, 0]
-    coef = torch.linalg.lstsq(mat.to(device), y_eval.unsqueeze(dim=2).to(device),
-                              driver='gelsy' if device == 'cpu' else 'gels').solution[:, :, 0]
+    coef = torch.linalg.lstsq(mat.to('cpu'), y_eval.unsqueeze(dim=2).to('cpu'),
+                             driver='gelsy').solution[:, :, 0]
     return coef.to(device)


### PR DESCRIPTION
Hi Ziming!

I noticed using "update_grid_from_samples", which really improves the training on CPU,  leads to NaN in the network and gradient when used on CUDA. The problem seems to be coming from the fit of the B spline coefficients in spline.py:

coef = torch.linalg.lstsq(mat.to(device), y_eval.unsqueeze(dim=2).to(device),
                              driver='gelsy' if device == 'cpu' else 'gels').solution[:, :, 0]

Here "mat" is the B spline function which are not a full rank matrix depending on the samples. It seems that the driver 'gels' cannot handle degenerate matrices. So I just sent that operation to the CPU, which allows to use 'gelsy' and handle degenerate matrices. Perhaps there is a better solution but I'm committing it just in case, since it worked for me on both CUDA and MPS.

