### PR TITLE
Adding a relevant line to explain the torch shape output in curve2coeff…

### DIFF
--- a/kan/spline.py
+++ b/kan/spline.py
@@ -130,6 +130,7 @@ def curve2coef(x_eval, y_eval, grid, k, device="cpu"):
     >>> x_eval = torch.normal(0,1,size=(num_spline, num_sample))
     >>> y_eval = torch.normal(0,1,size=(num_spline, num_sample))
     >>> grids = torch.einsum('i,j->ij', torch.ones(num_spline,), torch.linspace(-1,1,steps=num_grid_interval+1))
+    >>> curve2coef(x_eval, y_eval, grid, k, device="cpu").shape 
     torch.Size([5, 13])
     '''
     # x_eval: (size, batch); y_eval: (size, batch); grid: (size, grid); k: scalar


### PR DESCRIPTION
While trying to understand the B_batch function, I initially thought the output printed in the curve2coeff example was trying to show the shape of the grid variable. This confused me as grids dimension. is [5,11].

Hence, just adding this code `curve2coef(x_eval, y_eval, grid, k, device="cpu").shape` to show that otput `torch.Size([5, 13])` corresponds to this line.