### PR TITLE
chore: Create CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,31 @@
+cff-version: 1.2.0
+title: "KAN: Kolmogorov-Arnold Networks"
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+preferred-citation:
+  type: article
+  authors:
+    - given-names: Ziming
+      family-names: Liu
+    - given-names: Yixuan
+      family-names: Wang
+    - given-names: Sachin
+      family-names: Vaidya
+    - given-names: Fabian
+      family-names: Ruehle
+    - given-names: James
+      family-names: Halverson
+    - given-names: Marin
+      family-names: 'Solja{\v{c}}i{\''c}'
+    - given-names: Thomas Y
+      family-names: Hou
+    - given-names: Max
+      family-names: Tegmark
+  doi: "10.48550/arXiv.2404.19756"
+  journal: "arXiv preprint arXiv:2404.19756"
+  title: "KAN: Kolmogorov-Arnold Networks"
+  year: 2024
+  repository-code: 'https://github.com/KindXiaoming/pykan'
+  url: 'https://kindxiaoming.github.io/pykan/'
+  license: MIT


### PR DESCRIPTION
Dear KANs team, thank you very much for your research on the KANs algorithm. 

This PullRequest mainly adds the `CITATION.cff` file, which will add a **Cite this repository** button in the repo's properties column. For details about the key-value pairs of `CITATION.cff`, please refer to [about-citation-files].

[about-citation-files]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files

```py3
@article{Liu_KAN_Kolmogorov-Arnold_Networks_2024,
author = {Liu, Ziming and Wang, Yixuan and Vaidya, Sachin and Ruehle, Fabian and Halverson, James and Solja{\v{c}}i{\'c}, Marin and Hou, Thomas Y and Tegmark, Max},
doi = {10.48550/arXiv.2404.19756},
journal = {arXiv preprint arXiv:2404.19756},
title = {{KAN: Kolmogorov-Arnold Networks}},
url = {https://github.com/KindXiaoming/pykan},
year = {2024}
}
```

![image](https://github.com/KindXiaoming/pykan/assets/44714368/77c37fda-2296-457f-a67d-44727af9a189)
