### PR TITLE
Random seed

### DIFF
--- a/kan/KAN.py
+++ b/kan/KAN.py
@@ -78,7 +78,7 @@ class KAN(nn.Module):
     '''
 
     def __init__(self, width=None, grid=3, k=3, noise_scale=0.1, scale_base_mu=0.0, scale_base_sigma=1.0, base_fun=torch.nn.SiLU(), symbolic_enabled=True, bias_trainable=False, grid_eps=1.0, grid_range=[-1, 1], sp_trainable=True, sb_trainable=True,
-                 device='cpu', seed=0):
+                 device='cpu', seed=None):
         '''
         initalize a KAN model
         
@@ -122,6 +122,9 @@ class KAN(nn.Module):
         ((2, 5), (5, 1))
         '''
         super(KAN, self).__init__()
+
+        if seed is None:
+            seed = np.random.randint(0, 1e3)
 
         torch.manual_seed(seed)
         np.random.seed(seed)

--- a/kan/LBFGS.py
+++ b/kan/LBFGS.py
@@ -302,8 +302,6 @@ class LBFGS(Optimizer):
                 and returns the loss.
         """
         
-        torch.manual_seed(0)
-        
         assert len(self.param_groups) == 1
 
         # Make sure the closure is always called with grad enabled

--- a/kan/MultKAN.py
+++ b/kan/MultKAN.py
@@ -23,9 +23,12 @@ from .utils import SYMBOLIC_LIB
 class MultKAN(nn.Module):
 
     # include mult_ops = []
-    def __init__(self, width=None, grid=3, k=3, mult_arity = 2, noise_scale=1.0, scale_base_mu=0.0, scale_base_sigma=1.0, base_fun='silu', symbolic_enabled=True, affine_trainable=False, grid_eps=1.0, grid_range=[-1, 1], sp_trainable=True, sb_trainable=True, device='cpu', seed=0, save_plot_data=True, sparse_init=False, auto_save=True, first_init=True, ckpt_path='./model', state_id=0):
+    def __init__(self, width=None, grid=3, k=3, mult_arity = 2, noise_scale=1.0, scale_base_mu=0.0, scale_base_sigma=1.0, base_fun='silu', symbolic_enabled=True, affine_trainable=False, grid_eps=1.0, grid_range=[-1, 1], sp_trainable=True, sb_trainable=True, device='cpu', seed=None, save_plot_data=True, sparse_init=False, auto_save=True, first_init=True, ckpt_path='./model', state_id=0):
         
         super(MultKAN, self).__init__()
+
+        if seed is None:
+            seed = np.random.randint(0, 1e3)
 
         torch.manual_seed(seed)
         np.random.seed(seed)

--- a/kan/utils.py
+++ b/kan/utils.py
@@ -66,7 +66,7 @@ def create_dataset(f,
                    normalize_input=False,
                    normalize_label=False,
                    device='cpu',
-                   seed=0):
+                   seed=None):
     '''
     create dataset
     
@@ -102,6 +102,9 @@ def create_dataset(f,
     >>> dataset['train_input'].shape
     torch.Size([100, 2])
     '''
+
+    if seed is None:
+        seed = np.random.randint(0, 1e3)
 
     np.random.seed(seed)
     torch.manual_seed(seed)


### PR DESCRIPTION
This pull request addresses the issue with:
1. KAN, MultKAN and utils set the random seed to be 0, unless argument as int is provided by the user.
2. The arguments were changed to None as default; In this instance, the init function will set the seed to a random integer [0, 1e3], unless argument as int is provided by the user.
3. This way the model will allow randomness in the initialisation instead of always using 0. Similar strategies are used in pytorch or sklearn.