### PR TITLE
add sum and mult symbol pngs to the installation

### DIFF
--- a/pykan.egg-info/SOURCES.txt
+++ b/pykan.egg-info/SOURCES.txt
@@ -8,6 +8,8 @@ kan/Symbolic_KANLayer.py
 kan/__init__.py
 kan/spline.py
 kan/utils.py
+kan/assets/img/mult_symbol.png
+kan/assets/img/sum_symbol.png
 kan/figures/lock.png
 pykan.egg-info/PKG-INFO
 pykan.egg-info/SOURCES.txt

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ setuptools.setup(
     package_data={  
         'pykan': [
             'figures/lock.png',
+            'assets/img/sum_symbol.png',
+            'assets/img/mult_symbol.png',
         ],
     },
     classifiers=[


### PR DESCRIPTION
this pr makes sure that `assets/img/sum_symbol.png` and `assets/img/mult_symbol.png` are included in the distribution.

fixes #341