### PR TITLE
`unfix_symbolic_all` produced errors

### DIFF
--- a/kan/MultKAN.py
+++ b/kan/MultKAN.py
@@ -951,14 +951,14 @@ class MultKAN(nn.Module):
         if log_history:
             self.log_history('unfix_symbolic')
 
-    def unfix_symbolic_all(self):
+    def unfix_symbolic_all(self, log_history=True):
         '''
         unfix all activation functions.
         '''
         for l in range(len(self.width) - 1):
-            for i in range(self.width[l]):
-                for j in range(self.width[l + 1]):
-                    self.unfix_symbolic(l, i, j)
+            for i in range(self.width_in[l]):
+                for j in range(self.width_out[l + 1]):
+                    self.unfix_symbolic(l, i, j, log_history=True)
 
     def get_range(self, l, i, j, verbose=True):
         '''

--- a/kan/MultKAN.py
+++ b/kan/MultKAN.py
@@ -958,7 +958,7 @@ class MultKAN(nn.Module):
         for l in range(len(self.width) - 1):
             for i in range(self.width_in[l]):
                 for j in range(self.width_out[l + 1]):
-                    self.unfix_symbolic(l, i, j, log_history=True)
+                    self.unfix_symbolic(l, i, j, log_history)
 
     def get_range(self, l, i, j, verbose=True):
         '''


### PR DESCRIPTION
**Motivation**: The `unfix_symbolic_all` function would produce an error because `width` should be `width_in` and `width_out` in the outer and inner loop, respectively.

**Proposition**: Fixed the `width` parameter accordingly, and also passed the `log_history` parameter as well.