### PR TITLE
Fixed device mismatch error of Symbolic_KANLayer

### DIFF
--- a/kan/Symbolic_KANLayer.py
+++ b/kan/Symbolic_KANLayer.py
@@ -216,9 +216,9 @@ class Symbolic_KANLayer(nn.Module):
                 self.funs[j][i] = fun
                 self.funs_avoid_singularity[j][i] = fun_avoid_singularity
                 if random == False:
-                    self.affine.data[j][i] = torch.tensor([1.,0.,1.,0.])
+                    self.affine.data[j][i] = torch.tensor([1.,0.,1.,0.], device=self.device)
                 else:
-                    self.affine.data[j][i] = torch.rand(4,) * 2 - 1
+                    self.affine.data[j][i] = torch.rand(4, device=self.device) * 2 - 1
                 return None
             else:
                 #initialize from x & y and fun
@@ -237,9 +237,9 @@ class Symbolic_KANLayer(nn.Module):
             self.funs[j][i] = fun
             self.funs_avoid_singularity[j][i] = fun
             if random == False:
-                self.affine.data[j][i] = torch.tensor([1.,0.,1.,0.])
+                self.affine.data[j][i] = torch.tensor([1.,0.,1.,0.], device=self.device)
             else:
-                self.affine.data[j][i] = torch.rand(4,) * 2 - 1
+                self.affine.data[j][i] = torch.rand(4, device=self.device) * 2 - 1
             return None
         
     def swap(self, i1, i2, mode='in'):


### PR DESCRIPTION
Congratulations on this awesome project! I am pretty much amazed by the new possibility this project has opened up.

While trying MultKAN, I just have found a minor bug. Few lines of change fixes the issue.

### Problem Specification

Device mismatch error occurs in performing `MultKAN.suggest_symbolic` when the model is explicitly uploaded to a device with `model.to('cuda:1')`. The problem was due to tensor declaration in `kan/Symbolic_KANLayer.py` where CPU tensors are declared regardless of the device on which the layer sits.

### Fixes

Changes are made only in `kan/Symbolic_KANLayer.py`. Every tensor explicitly declared in the file is defined with the device specification of `self.device`.

Hope this helps!