### PR TITLE
Update experiment1.ipynb

### DIFF
--- a/kan/experiments/experiment1.ipynb
+++ b/kan/experiments/experiment1.ipynb
@@ -206,7 +206,7 @@
     }
    },
    "cell_type": "code",
-   "source": "losses = model.train(dataset=dataset, opt='LBFGS', steps=20, device=device)",
+   "source": "losses = model.fit(dataset=dataset, opt='LBFGS', steps=20)",
    "id": "24cde08da2ea047a",
    "outputs": [
     {


### PR DESCRIPTION
Issue: model.train() raises additional argument error because it is calling train() function of torch nn.module, which has only 1 argument.
Fix: fit() method (available in MultKAN class file) is used to train the KAN model. 