### PR TITLE
auto_save=self.auto_save in model.prune()

### DIFF
--- a/kan/MultKAN.py
+++ b/kan/MultKAN.py
@@ -1680,7 +1680,7 @@ class MultKAN(nn.Module):
                 if i not in active_neurons_down[l]:
                     self.remove_node(l + 1, i, mode='down',log_history=False)
 
-        model2 = MultKAN(copy.deepcopy(self.width), grid=self.grid, k=self.k, base_fun=self.base_fun_name, mult_arity=self.mult_arity, ckpt_path=self.ckpt_path, auto_save=True, first_init=False, state_id=self.state_id, round=self.round).to(self.device)
+        model2 = MultKAN(copy.deepcopy(self.width), grid=self.grid, k=self.k, base_fun=self.base_fun_name, mult_arity=self.mult_arity, ckpt_path=self.ckpt_path, auto_save=self.auto_save, first_init=False, state_id=self.state_id, round=self.round).to(self.device)
         model2.load_state_dict(self.state_dict())
         
         width_new = [self.width[0]]


### PR DESCRIPTION
change model2=MultKAN(..., auto_save=Ture, ...) to auto_save=self.auto_save, as when we set auto_save=False, then prune the model, it'll be saved and file './model/history.txt' can't be found
#362 