### PR TITLE
Fix Extra Slicing Operator in `feynman.py` (Equation 114)

### DIFF
--- a/kan/feynman.py
+++ b/kan/feynman.py
@@ -697,7 +697,7 @@ def get_feynman_dataset(name):
     if name == 'Jackson 2.11' or name == 114:
         symbol = q, eps, y, Ve, d = symbols('q epsilon y V_e d')
         expr = q/(4*pi*eps*y**2)*(4*pi*eps*Ve*d-q*d*y**3/(y**2-d**2)**2)
-        f = lambda x: x[:,[0]]/(4*tpi*x[:,[1]]*x[:,x[:,[2]]]**2)*(4*tpi*x[:,[1]]*x[:,[3]]*x[:,[4]]-x[:,[0]]*x[:,[4]]*x[:,[2]]**3/(x[:,[2]]**2-x[:,[4]]**2)**2)
+        f = lambda x: x[:,[0]]/(4*tpi*x[:,[1]]*x[:,[2]]]**2)*(4*tpi*x[:,[1]]*x[:,[3]]*x[:,[4]]-x[:,[0]]*x[:,[4]]*x[:,[2]]**3/(x[:,[2]]**2-x[:,[4]]**2)**2)
         ranges = [[0,1],[0.5,2],[1,2],[0,1],[0,1]]
         
     if name == 'Jackson 3.45' or name == 115:


### PR DESCRIPTION
The equation 114 contains an additional slicing operator that triggers an exception when attempting to create a dataset.