### PR TITLE
Added support for saving checkpoints with CUDA device numbers

### DIFF
--- a/kan/MultKAN.py
+++ b/kan/MultKAN.py
@@ -534,6 +534,9 @@ class MultKAN(nn.Module):
             round = model.round,
             device = str(model.device)
         )
+        
+        if dic["device"].isdigit():
+            dic["device"] = int(model.device)
 
         for i in range (model.depth):
             dic[f'symbolic.funs_name.{i}'] = model.symbolic_fun[i].funs_name


### PR DESCRIPTION
## Summary:
See #515 for a write up of the problem

## Solution:
Line 538 of `kan/MultKAN.py` checking if the string is a digit, and if so saving the digit as an int rather than a string
```python
        if dic["device"].isdigit():
            dic["device"] = int(model.device)
```

## Testing:
Ran the cases that were breaking in #515 and the code was working well. Rather ran doing a one-lined fix for this, I tried to match the coding style of the file.
